### PR TITLE
Correct spurious test failures

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -210,7 +210,7 @@ check_contains () {
 # Check that $2 and $3 are equal. $1 is the test name to display
 equal_test () {
     echo -n "$1:	"
-    if [ "$2" == "$3" ]; then
+    if [ "$2" = "$3" ]; then
 	PASS
     else
 	FAIL "$2 != $3"


### PR DESCRIPTION
Four of the tests are reported as failure due to a bad operation in the equal_test() function. Fix this.